### PR TITLE
Added ESRI World Hillshade

### DIFF
--- a/2024/bikerouter-external-overlays.md
+++ b/2024/bikerouter-external-overlays.md
@@ -8,6 +8,7 @@
 | Strava Heatmap Bike | `https://proxy.nakarte.me/https/heatmap-external-b.strava.com/tiles-auth/ride/red/{z}/{x}/{y}.png?px=256` |
 | Strava Heatmap Run | `https://proxy.nakarte.me/https/heatmap-external-b.strava.com/tiles-auth/run/red/{z}/{x}/{y}.png?px=256` |
 | [Basemap.de Hillshade](https://basemap.de/web_raster_schummerung/) | `https://sgx.geodatenzentrum.de/wmts_basemapde_schummerung/tile/1.0.0/de_basemapde_web_raster_hillshade/default/GLOBAL_WEBMERCATOR/{z}/{y}/{x}.png` |
+| [ESRI World Hillshade](https://arcg.is/00b0vC) | `http://services.arcgisonline.com/ArcGIS/rest/services/Elevation/World_Hillshade/MapServer/tile/{z}/{y}/{x}` |
 | Garmin Gravel	Heatmap | `https://connecttile.garmin.com/GRAVEL_BIKING/{z}/{x}/{y}.png` |
 | Garmin Road	Heatmap | `https://connecttile.garmin.com/ROAD_CYCLING/{z}/{x}/{y}.png` |
 | [Open Railway Map](https://openrailwaymap.org/) | `https://tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png` |


### PR DESCRIPTION
Found another nice hillshade layer. Not the same fidelity as basemap.de hillshade (primarily due to suboptimal lighting / contrast choices and overly aggressive vegetation filtering), but worldwide coverage - perfect for planning outside of Germany =)